### PR TITLE
use given levels without taking abs

### DIFF
--- a/samples/absolute.html
+++ b/samples/absolute.html
@@ -29,13 +29,13 @@
       borderWidth: 1,
       data: [
         50,
-        100,
+        -5,
         130,
         0
       ],
       errorBars: {
         'Value': {plus: 80, minus: 20},
-        'Value 2': {plus: 120, minus: 80}
+        'Value 2': {plus: 120, minus: -30}
       }
     }]
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -206,8 +206,8 @@ const ErrorBarsPlugin = {
           const errorBarColor = options.color ? options.color : bar.color;
           const value = vScale.getRightValue(bar.value);
 
-          const plusValue = options.absoluteValues ? Math.abs(errorBarData.plus) : (value + Math.abs(errorBarData.plus));
-          const minusValue = options.absoluteValues ? Math.abs(errorBarData.minus) : (value - Math.abs(errorBarData.minus));
+          const plusValue = options.absoluteValues ? errorBarData.plus : (value + Math.abs(errorBarData.plus));
+          const minusValue = options.absoluteValues ? errorBarData.minus : (value - Math.abs(errorBarData.minus));
 
           const plus = vScale.getPixelForValue(plusValue);
           const minus = vScale.getPixelForValue(minusValue);


### PR DESCRIPTION
When the error levels are directly specified, use them as given without taking `abs`.   