### PR TITLE
Attach error bar drawing to 'afterDatasetsDraw' hook so that tooltips…

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -156,7 +156,7 @@ const ErrorBarsPlugin = {
    * @param easingValue animation function
    * @param options plugin options
    */
-  afterDraw(chart, easingValue, options) {
+  afterDatasetsDraw(chart, easingValue, options) {
     // wait for easing value to reach 1 at the first render, after that draw immediately
     chart.__renderedOnce = chart.__renderedOnce || easingValue === 1;
 


### PR DESCRIPTION
… aren't covered up by the error bars.

This fixes #8.