### PR TITLE
Handling unreliable position of hidden flag in metadata

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -189,7 +189,10 @@ const ErrorBarsPlugin = {
     // map error bar to barchart bar via label property
     barchartCoords.forEach((dataset, i) => {
       if (chart.data.datasets && chart.data.datasets[i] && chart.data.datasets[i]._meta && typeof chart.data.datasets[i]._meta === 'object') {
-        for (const meta of Object.values(chart.data.datasets[i]._meta)) {
+        const metaList = Array.isArray(chart.data.datasets[i]._meta)
+          ? chart.data.datasets[i]._meta
+          : Object.values(chart.data.datasets[i]._meta);
+        for (const meta of metaList) {
           if (meta.hidden) {
             return;
           }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -188,10 +188,11 @@ const ErrorBarsPlugin = {
 
     // map error bar to barchart bar via label property
     barchartCoords.forEach((dataset, i) => {
-      if (chart.data.dataset[i]._meta != null && chart.data.dataset[i]._meta.length > 0) {
-        var hidden = chart.data.datasets[i]._meta[0].hidden;
-        if (hidden) {
-          return;
+      if (chart.data.datasets && chart.data.datasets[i] && chart.data.datasets[i]._meta && typeof chart.data.datasets[i]._meta === 'object') {
+        for (const meta of Object.values(chart.data.datasets[i]._meta)) {
+          if (meta.hidden) {
+            return;
+          }
         }
       }
 


### PR DESCRIPTION
refs #12 #21 #24

The metadata list seems to actually be an object with numerical strings as keys in 2.8.0, so the previous implementation wouldn't cover that.